### PR TITLE
Fix 32 bit df on 64 bit Fedora and warn others.

### DIFF
--- a/pack/df_linux/df
+++ b/pack/df_linux/df
@@ -3,5 +3,15 @@ DF_DIR=$(dirname "$0")
 cd "${DF_DIR}"
 export SDL_DISABLE_LOCK_KEYS=1 # Work around for bug in Debian/Ubuntu SDL patch.
 #export SDL_VIDEO_CENTERED=1 # Centre the screen.  Messes up resizing.
+
+# >>> LNP modification:
+
+#apply any ARC/distro fixes
+source "$DF_DIR/distro_fixes.sh"
+LD_PRELOAD="$LD_PRELOAD $PRELOAD_LIB" ./libs/Dwarf_Fortress "$@" # Go, go, go! :)
+exit $?
+
+# <<< LNP modification:
+
 ./libs/Dwarf_Fortress "$@" # Go, go, go! :)
 

--- a/pack/df_linux/dfhack
+++ b/pack/df_linux/dfhack
@@ -38,12 +38,12 @@ old_tty_settings=$(stty -g)
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./hack/libs":"./hack"
 
-PRELOAD_LIB=./hack/libdfhack.so
+PRELOAD_LIB="$PRELOAD_LIB ./hack/libdfhack.so"
 
 case "$1" in
   -g | --gdb)
     shift
-    echo "set environment LD_PRELOAD=$PRELOAD_LIB" > gdbcmd.tmp
+    echo "set environment LD_PRELOAD=\"$PRELOAD_LIB\"" > gdbcmd.tmp
     echo "set environment MALLOC_PERTURB_=45" >> gdbcmd.tmp
     gdb $DF_GDB_OPTS -x gdbcmd.tmp ./libs/Dwarf_Fortress "$@"
     rm gdbcmd.tmp
@@ -51,21 +51,21 @@ case "$1" in
     ;;
   -h | --helgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   -v | --valgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   -c | --callgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   *)
-    setarch i386 -R env LD_PRELOAD=$PRELOAD_LIB ./libs/Dwarf_Fortress "$@"
+    setarch i386 -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
 esac

--- a/pack/df_linux/dfhack
+++ b/pack/df_linux/dfhack
@@ -34,6 +34,13 @@ fi
 # Save current terminal settings
 old_tty_settings=$(stty -g)
 
+# >>> LNP modification:
+
+#apply any ARC/distro fixes
+source "$DF_DIR/distro_fixes.sh"
+
+# <<< LNP modification:
+
 # Now run
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./hack/libs":"./hack"

--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# This script checks the system for ARCH and disto details
+# and sets up env variables as workaround for use by the
+# df/dfhack scripts.
+
+function dlog() {
+    echo -e "\033[0;32m[distro_fixes]\033[0;00m $1 $2"
+}
+
+dlog "INFO" "Checking whether any ARCH/distro specific fixes are required..."
+
+# find df bin relative to location of this shell scrip
+DF_BIN_LOCATION=$(readlink -f $(dirname "$0")/libs/Dwarf_Fortress)
+
+if [ ! -f $DF_BIN_LOCATION ]; then
+    dlog "Warning: did not find df binary at $DF_BIN_LOCATION"
+fi
+
+# Detect Stuff
+OS=$(uname -s)
+ARCH=$(uname -m)
+VER=$(uname -r)
+DF_ARCH=$(file "$DF_BIN_LOCATION" | grep -Po '(32|64)-bit')
+
+# by default don't preload anything
+
+# this needs to be picked up by df/dfhack and included in LD_PRELOAD
+export PRELOAD_LIB
+
+if [ -e "/usr/bin/lsb_release" ]; then
+    OS=$(lsb_release -si)
+    ARCH=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
+    VER=$(lsb_release -sr)
+fi
+
+# Report Stuff
+
+dlog "INFO" "OS: $OS"
+dlog "INFO" "ARCH: $ARCH"
+dlog "INFO" "VER: $VER"
+dlog "INFO" "DF_ARCH: $DF_ARCH"
+dlog "INFO" "DF_BIN_LOCATION: $DF_BIN_LOCATION"
+
+# Optionally, Fix stuff
+
+# 32 bit df on 64 bit linux must give loader precedence to the 32 bit libz
+# to avoid errors when libpng tries to load images.
+# Some threads suggest png files should be also be converted to bmp as a fix
+# I haven't found this necessary if LD_PRELOAD is properly set (on fedora).
+
+if [ x"$DF_ARCH" == x'32-bit' ] && [ x"$ARCH" == x'64' ]; then
+
+    # Fedora 21/64-bit is tested
+    if [ x"$OS" == x'Fedora' ]; then
+        export PRELOAD_LIB=/usr/lib/libz.so;
+        dlog "INFO" "32 bit df on $OS/64bit detected. Will set LD_PRELOAD to $PRELOAD_LIB...."
+    # Add your distro here...
+    elif [ x"$OS" == x'MyFooDistro' ]; then
+        export PRELOAD_LIB="abspath_to_32bit_libz";
+        dlog "INFO" "32 bit df on $OS/64bit detected. Will set LD_PRELOAD to $PRELOAD_LIB...."
+    else
+        dlog "WARN" "32bit 'Dwarf_Fortress' on 64bit OS detected. see $0 script for fix using LD_PRELOAD."
+
+    fi
+
+fi
+
+dlog "INFO" "Done"


### PR DESCRIPTION
There's a common issue on 64 bit distros where df fails with errors similar to `cannot load "data/art/foo.png"` because ld loads the 64bit version of libz required by libpng rather then the 32 bit version.
This fixes the problem on fedora and emits a warning on other distros (since I haven't tested others).
