### PR TITLE
LD_PRELOAD should use colon rather then space as delimiter

### DIFF
--- a/pack/df_linux/df
+++ b/pack/df_linux/df
@@ -8,7 +8,7 @@ export SDL_DISABLE_LOCK_KEYS=1 # Work around for bug in Debian/Ubuntu SDL patch.
 
 #apply any ARC/distro fixes
 source "$DF_DIR/distro_fixes.sh"
-LD_PRELOAD="$LD_PRELOAD $PRELOAD_LIB" ./libs/Dwarf_Fortress "$@" # Go, go, go! :)
+LD_PRELOAD="$LD_PRELOAD:$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@" # Go, go, go! :)
 exit $?
 
 # <<< LNP modification:

--- a/pack/df_linux/dfhack
+++ b/pack/df_linux/dfhack
@@ -45,7 +45,7 @@ source "$DF_DIR/distro_fixes.sh"
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./hack/libs":"./hack"
 
-PRELOAD_LIB="$PRELOAD_LIB ./hack/libdfhack.so"
+PRELOAD_LIB="$PRELOAD_LIB:./hack/libdfhack.so"
 
 case "$1" in
   -g | --gdb)

--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -57,11 +57,11 @@ if [ x"$DF_ARCH" == x'32-bit' ] && [ x"$ARCH" == x'x86_64' ]; then
 
     # Fedora 21/64-bit is tested
     if [ x"$OS" == x'Fedora' ]; then
-        export PRELOAD_LIB="$PRELOAD_LIB /usr/lib/libz.so.1";
+        export PRELOAD_LIB="$PRELOAD_LIB:/usr/lib/libz.so.1";
         dlog "INFO" "32 bit df on $OS/64bit detected. Will set LD_PRELOAD to $PRELOAD_LIB...."
     # Add your distro here...
     elif [ x"$OS" == x'MyFooDistro' ]; then
-        export PRELOAD_LIB="abspath_to_32bit_libz";
+        export PRELOAD_LIB="$PRELOAD_LIB:<abspath_to_32bit_libz>";
         dlog "INFO" "32 bit df on $OS/64bit detected. Will set LD_PRELOAD to $PRELOAD_LIB...."
     else
         dlog "WARN" "32bit 'Dwarf_Fortress' on 64bit OS detected. see $0 script for fix using LD_PRELOAD."


### PR DESCRIPTION
Everything seemed to work fine, but the manpage says differently.
