### PR TITLE
distro_fixes.sh: bash dirname !=(=) python os.path.dirname.

### DIFF
--- a/pack/df_linux/df
+++ b/pack/df_linux/df
@@ -1,5 +1,5 @@
 #!/bin/sh
-DF_DIR=$(dirname "$0")
+DF_DIR=$(dirname $(readlink -f $BASH_SOURCE))
 cd "${DF_DIR}"
 export SDL_DISABLE_LOCK_KEYS=1 # Work around for bug in Debian/Ubuntu SDL patch.
 #export SDL_VIDEO_CENTERED=1 # Centre the screen.  Messes up resizing.

--- a/pack/df_linux/dfhack
+++ b/pack/df_linux/dfhack
@@ -16,7 +16,7 @@
 #     DF_HELGRIND_OPTS: Options to pass to helgrind, if it's being run
 #     DF_POST_CMD: Shell command to be run at very end of script
 
-DF_DIR=$(dirname "$0")
+DF_DIR=$(dirname $(readlink -f $BASH_SOURCE))
 cd "${DF_DIR}"
 export SDL_DISABLE_LOCK_KEYS=1 # Work around for bug in Debian/Ubuntu SDL patch.
 #export SDL_VIDEO_CENTERED=1 # Centre the screen.  Messes up resizing.

--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -16,7 +16,7 @@ fi
 dlog "INFO" "Checking whether any ARCH/distro specific fixes are required..."
 
 # find df bin relative to location of this shell script
-DF_BIN_LOCATION=$(readlink -f $(dirname "$1")/libs/Dwarf_Fortress)
+DF_BIN_LOCATION="$1/libs/Dwarf_Fortress"
 
 if [ ! -f $DF_BIN_LOCATION ]; then
     dlog "WARN" "did not find df binary at $DF_BIN_LOCATION"


### PR DESCRIPTION
Python:

``` python
os.path.dirname(path)

    Return the directory name of pathname path. This is the first element of the pair returned by passing path to the function split().
```

Bash:

``` text
DIRNAME(1)                                  User Commands                                  DIRNAME(1)

NAME
       dirname - strip last component from file name

```

My bad.

Tested launching from shell and from gui, dfhack and df, in curdir and away.

closes #28. 
